### PR TITLE
fix: udpate stopCluster and stopGroup examples

### DIFF
--- a/docs/How-to-Guides/search-on-tictactrip/_get-all-stop-groups.md
+++ b/docs/How-to-Guides/search-on-tictactrip/_get-all-stop-groups.md
@@ -4,8 +4,6 @@ sidebar_position: 3
 
 # Get all stop groups
 
-
-
 ```
 curl --location --request GET 'https://api.tictactrip.eu/v2/stopGroups' \
 --header 'Authorization: Bearer token'
@@ -21,39 +19,33 @@ curl --location --request GET 'https://api.tictactrip.eu/v2/stopGroups' \
     "name": "Paris Montparnasse 1 Et 2",
     "city": "Paris",
     "region": "Île-de-France",
-    "country": "fr",
+    "country": "FR",
     "latitude": 48.8409,
     "longitude": 2.3205,
-    "transportTypes": [
-      "bus",
-      "train"
-    ]
+    "transportTypes": ["bus", "train"]
+    //...
   },
   {
     "id": "g|FRpamo3va_@u09tug",
     "name": "Paris Montparnasse 3 Vaugirard",
     "city": "Paris",
     "region": "Île-de-France",
-    "country": "fr",
+    "country": "FR",
     "latitude": 48.8409,
     "longitude": 2.3205,
-    "transportTypes": [
-      "bus",
-      "train"
-    ]
+    "transportTypes": ["bus", "train"]
+    //...
   },
   {
     "id": "g|FRparsaila@u09whc",
     "name": "Paris Saint-Lazare",
     "city": "Paris",
     "region": "Île-de-France",
-    "country": "fr",
+    "country": "FR",
     "latitude": 48.8756,
     "longitude": 2.3254,
-    "transportTypes": [
-      "bus",
-      "train"
-    ]
+    "transportTypes": ["bus", "train"]
+    //...
   }
   //...
 ]

--- a/docs/How-to-Guides/search-on-tictactrip/_get-origin-and-destination-ids.md
+++ b/docs/How-to-Guides/search-on-tictactrip/_get-origin-and-destination-ids.md
@@ -7,7 +7,6 @@ sidebar_position: 1
 In order to search on **[Tictactrip](https://www.tictactrip.eu/)** you will need two **[stopCluster](../../Reference/stop-cluster.md)** ids, one for the origin and one for the destination.  
 For example `c|FRpralvano@u0hf0` and `c|FRmoutiers@u0hdu`. You can notice that they are always prefixed by a "c" for "cluster".
 
-
 ```
 curl --location --request GET 'https://api.tictactrip.eu/v2/stopClusters' \
 --header 'Authorization: Bearer token'
@@ -23,18 +22,20 @@ curl --location --request GET 'https://api.tictactrip.eu/v2/stopClusters' \
     "name": "Pralognan La Vanoise",
     "city": "Pralognan La Vanoise",
     "region": "Auvergne-Rhône-Alpes",
-    "country": "fr",
+    "country": "FR",
     "latitude": 45.3819,
     "longitude": 6.72121
+    //...
   },
   {
     "id": "c|FRmoutiers@u0hdu",
     "name": "Moûtiers",
     "city": "Moûtiers",
     "region": "Auvergne-Rhône-Alpes",
-    "country": "fr",
+    "country": "FR",
     "latitude": 45.4852,
     "longitude": 6.5291
+    //...
   },
   {
     "id": "c|PTvilareal@ez66z",
@@ -44,6 +45,7 @@ curl --location --request GET 'https://api.tictactrip.eu/v2/stopClusters' \
     "country": "pt",
     "latitude": 41.2979376,
     "longitude": -7.75298965523
+    //...
   }
   //...
 ]

--- a/docs/How-to-Guides/search-on-tictactrip/tutorial.md
+++ b/docs/How-to-Guides/search-on-tictactrip/tutorial.md
@@ -2,7 +2,6 @@
 sidebar_position: 1
 ---
 
-
 # Tutorial
 
 ## Get origin and destination ids
@@ -14,6 +13,7 @@ For example `c|FRpralvano@u0hf0` and `c|FRmoutiers@u0hdu`. You can notice that t
 curl --location --request GET 'https://api.tictactrip.eu/v2/stopClusters' \
 --header 'Authorization: Bearer token'
 ```
+
 ### Response body example
 
 ```json
@@ -24,27 +24,30 @@ curl --location --request GET 'https://api.tictactrip.eu/v2/stopClusters' \
     "name": "Pralognan La Vanoise",
     "city": "Pralognan La Vanoise",
     "region": "Auvergne-Rhône-Alpes",
-    "country": "fr",
+    "country": "FR",
     "latitude": 45.3819,
     "longitude": 6.72121
+    //...
   },
   {
     "id": "c|FRmoutiers@u0hdu",
     "name": "Moûtiers",
     "city": "Moûtiers",
     "region": "Auvergne-Rhône-Alpes",
-    "country": "fr",
+    "country": "FR",
     "latitude": 45.4852,
     "longitude": 6.5291
+    //...
   },
   {
     "id": "c|PTvilareal@ez66z",
     "name": "Vila Real",
     "city": "Vila Real",
     "region": "Norte",
-    "country": "pt",
+    "country": "PT",
     "latitude": 41.2979376,
     "longitude": -7.75298965523
+    //...
   }
   //...
 ]
@@ -176,7 +179,7 @@ curl --location --request POST 'https://api.tictactrip.eu/v2/results' \
           "co2g": 669
         }
       ]
-    },
+    }
     //...
   }
 }

--- a/docs/Reference/_stop-cluster.md
+++ b/docs/Reference/_stop-cluster.md
@@ -5,19 +5,22 @@ sidebar_position: 4
 # Stop Cluster
 
 ## Definition
+
 A **stopCluster** is a collection of **[stopGroups](./stop-group.md)**. It corresponds to a user intent. It is often illustrated by a city, but it can be anything the user is supposed to be looking for.
 
-
 ## Example
+
 "Paris" is a **stopCluster**.
+
 ```json
 {
   "id": "c|FRparis___@u09tv",
   "name": "Paris",
   "city": "Paris",
   "region": "Île-de-France",
-  "country": "fr",
+  "country": "FR",
   "latitude": 48.8566,
   "longitude": 2.3515
+  //...
 }
 ```

--- a/docs/Reference/_stop-group.md
+++ b/docs/Reference/_stop-group.md
@@ -5,10 +5,11 @@ sidebar_position: 3
 # Stop Group
 
 ## Definition
+
 A **stopGroup** is a set of stations. In "real world" semantics, a **stopGroup** matches a physical station, or several kinds of stations in the same real world location.
 
-
 ## Example
+
 A **stopGroup** "Paris Bercy" has two stations being the "train station" and the "bus station", but in practice, the user only wants to know about "Paris Bercy" as a transportation hub. Thus, we group them under a single entity named **stopGroup**.
 
 ```json
@@ -17,12 +18,10 @@ A **stopGroup** "Paris Bercy" has two stations being the "train station" and the
   "name": "Paris Bercy ",
   "city": "Paris",
   "region": "Île-de-France",
-  "country": "fr",
+  "country": "FR",
   "latitude": 48.8393,
   "longitude": 2.3829,
-  "transportTypes": [
-    "bus",
-    "train"
-  ]
+  "transportTypes": ["bus", "train"]
+  //...
 }
 ```

--- a/docs/Reference/glossary.md
+++ b/docs/Reference/glossary.md
@@ -171,10 +171,11 @@ A **stopGroup** "Paris Bercy" has two stations being the "train station" and the
   "name": "Paris Bercy ",
   "city": "Paris",
   "region": "Île-de-France",
-  "country": "fr",
+  "country": "FR",
   "latitude": 48.8393,
   "longitude": 2.3829,
   "transportTypes": ["bus", "train"]
+  //...
 }
 ```
 
@@ -194,8 +195,9 @@ A **stopCluster** is a collection of **[stopGroups](/docs/Reference/glossary#sto
   "name": "Paris",
   "city": "Paris",
   "region": "Île-de-France",
-  "country": "fr",
+  "country": "FR",
   "latitude": 48.8566,
   "longitude": 2.3515
+  //...
 }
 ```


### PR DESCRIPTION
# What
Update examples in the documentation.

# Why
Interfaces were changed in TS (and thus TSOA) but example were not updated.